### PR TITLE
Simplify aggregate errors, add support for aggregate media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
 /docs/_build/
 /.tox/
 /dist/
+/django_superform.egg-info/

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -207,16 +207,19 @@ class SuperFormMixin(object):
         Clean the form, including all formsets and add formset errors to the
         errors dict.
         """
+
+        # Note: is_valid() is False but errors are empty when form has no
+        # postdata yet.
         super(SuperFormMixin, self).full_clean()
         for field_name, composite in self.forms.items():
             composite.full_clean()
             errors = composite.errors
-            if errors:
+            if not composite.is_valid() and errors:
                 self._errors[field_name] = ErrorDict(errors)
         for field_name, composite in self.formsets.items():
             composite.full_clean()
             errors = composite.errors
-            if errors:
+            if not composite.is_valid() and errors:
                 self._errors[field_name] = ErrorList(errors)
 
 

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -208,19 +208,18 @@ class SuperFormMixin(object):
         errors dict.
         """
 
-        # Note: is_valid() is False but errors are empty when form has no
-        # postdata yet.
+        # is_valid() is False and errors are empty when form has no postdata
         super(SuperFormMixin, self).full_clean()
         for field_name, composite in self.forms.items():
             composite.full_clean()
             errors = composite.errors
             if not composite.is_valid() and errors:
-                self._errors[field_name] = ErrorDict(errors)
+                self._errors[field_name] = errors
         for field_name, composite in self.formsets.items():
             composite.full_clean()
             errors = composite.errors
             if not composite.is_valid() and errors:
-                self._errors[field_name] = ErrorList(errors)
+                self._errors[field_name] = errors
 
 
 class SuperModelFormMixin(SuperFormMixin):

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -210,12 +210,14 @@ class SuperFormMixin(object):
         super(SuperFormMixin, self).full_clean()
         for field_name, composite in self.forms.items():
             composite.full_clean()
-            if not composite.is_valid():
-                self._errors[field_name] = ErrorDict(composite.errors)
+            errors = composite.errors
+            if errors:
+                self._errors[field_name] = ErrorDict(errors)
         for field_name, composite in self.formsets.items():
             composite.full_clean()
-            if not composite.is_valid():
-                self._errors[field_name] = ErrorList(composite.errors)
+            errors = composite.errors
+            if errors:
+                self._errors[field_name] = ErrorList(errors)
 
 
 class SuperModelFormMixin(SuperFormMixin):

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -76,7 +76,7 @@ You're welcome.
 """
 
 from django import forms
-from django.forms.forms import DeclarativeFieldsMetaclass, ErrorDict, ErrorList
+from django.forms.forms import DeclarativeFieldsMetaclass
 from django.forms.models import ModelFormMetaclass
 from django.utils import six
 from .boundfield import CompositeBoundField
@@ -220,6 +220,15 @@ class SuperFormMixin(object):
             errors = composite.errors
             if not composite.is_valid() and errors:
                 self._errors[field_name] = errors
+
+    @property
+    def media(self):
+        """Propagate composite field media up with everything else."""
+        media = super(SuperFormMixin, self).media
+        for composite_name in self.composite_fields.keys():
+            form = self.get_composite_field_value(composite_name)
+            media += form.media
+        return media
 
 
 class SuperModelFormMixin(SuperFormMixin):

--- a/tests/test_superform.py
+++ b/tests/test_superform.py
@@ -65,3 +65,10 @@ class FormSetsInSuperFormsTests(TestCase):
         self.assertTrue(form.errors['username'])
         self.assertTrue(form.errors['emails'])
         self.assertIsInstance(form.errors['emails'], ErrorList)
+
+    def test_empty_form_has_no_errors(self):
+        """Empty forms have no errors."""
+        form = AccountForm()
+
+        self.assertFalse(form.is_valid())
+        self.assertFalse(form.errors)

--- a/tests/test_superform.py
+++ b/tests/test_superform.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.forms.forms import ErrorList
+from django.forms.forms import ErrorDict, ErrorList
 from django.forms.formsets import formset_factory
 from django.test import TestCase
 from django_superform import SuperForm, FormSetField
@@ -64,7 +64,7 @@ class FormSetsInSuperFormsTests(TestCase):
         self.assertEqual(form.is_valid(), False)
         self.assertTrue(form.errors['username'])
         self.assertTrue(form.errors['emails'])
-        self.assertIsInstance(form.errors['emails'], ErrorList)
+        self.assertIsInstance(form.errors['emails'], list)
 
     def test_empty_form_has_no_errors(self):
         """Empty forms have no errors."""
@@ -72,3 +72,20 @@ class FormSetsInSuperFormsTests(TestCase):
 
         self.assertFalse(form.is_valid())
         self.assertFalse(form.errors)
+
+    def test_formset_errors(self):
+        """Formset errors get propagated properly."""
+        data = {
+            'formset-emails-INITIAL_FORMS': 0,
+            'formset-emails-TOTAL_FORMS': 1,
+            'formset-emails-MAX_NUM_FORMS': 3,
+            'formset-emails-0-email': 'foobar',
+            'username': 'TestUser',
+        }
+        form = AccountForm(data)
+
+        expected_errors = [ErrorDict(
+            {u'email': ErrorList([u'Enter a valid email address.'])})]
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['emails'], expected_errors)

--- a/tests/test_superform.py
+++ b/tests/test_superform.py
@@ -117,7 +117,6 @@ class FormSetsInSuperFormsTests(TestCase):
 
         expected_js = UsernameInput.Media.js
         expected_css = EmailInput.Media.css
-        expected_css['all'] = list(expected_css['all'])
 
         self.assertEqual(form.media._css, expected_css)
         self.assertEqual(form.media._js, expected_js)


### PR DESCRIPTION
**EDIT**: I have added a few more commits since my original filing of this pull request so I'll summarize what I have done.

* I noticed in the `SuperFormMixin.full_clean` you explicitly create copies of all error dict/lists from composites. This included a conversion of formset errors from a list, as they are natively in Django, to either an `ErrorList` or `ErrorDict` (I forget which). Instead I have reverted the code to simply assign the result of the composite field's `full_clean()` directly into the superform's error dict. This preserves the basic list type of formset errors. This is probably a contentious change but I believe being simple and sticking as close as possible to what Django already does is best.

* As before, I have prevented keys with empty values from being set in the superform error dict. This means templates which check for errors by doing `{% if form.errors %}` continue to work.

* I have added support for form media in Superforms.

Once again thanks for your work on this library! I have been able to simplify a good amount of logic in my codebase, as well as use class-based views in more situations than before