### PR TITLE
Do not pass initial=None to formset constructors

### DIFF
--- a/django_superform/fields.py
+++ b/django_superform/fields.py
@@ -85,8 +85,12 @@ class CompositeField(BaseCompositeField):
         """
         kwargs = {
             'prefix': self.get_prefix(form, name),
-            'initial': self.get_initial(form, name),
         }
+
+        initial = self.get_initial(form, name)
+        if initial is not None:
+            kwargs['initial'] = initial
+
         kwargs.update(self.default_kwargs)
         return kwargs
 


### PR DESCRIPTION
BaseModelFormSet and thus everything declared with inlineformset_factory
doesn't have initial argument in the constructor.