### PR TITLE
Fix model formset render

### DIFF
--- a/django_superform/fields.py
+++ b/django_superform/fields.py
@@ -17,10 +17,11 @@ class BaseCompositeField(object):
     creation_counter = 0
 
     def __init__(self, required=True, widget=None, label=None, help_text='',
-                 localize=False):
+                 localize=False, disabled=False):
         self.required = required
         self.label = label
         self.help_text = help_text
+        self.disabled = disabled
 
         widget = widget or self.widget
         if isinstance(widget, type):

--- a/tests/test_formfield.py
+++ b/tests/test_formfield.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.template import Context, Template
 from django.test import TestCase
 from django_superform import SuperForm, FormField
 
@@ -95,3 +96,17 @@ class FormFieldTests(TestCase):
         self.assertEqual(address1['city'].value(), 'Testcity')
         self.assertEqual(address2['street'].value(), 'Barboulevard')
         self.assertEqual(address2['city'].value(), None)
+
+    def test_rendering_form_field(self):
+        form = MultiAddressForm(initial={
+            'address1': {
+                    'street': 'Fooway',
+            },
+            'address2': {
+                'street': 'Barboulevard',
+            }
+        })
+        template = Template('{{ form.address1 }} {{ form.address2 }}')
+        rendered = template.render(Context({'form': form}))
+        assert 'value="Fooway"' in rendered
+        assert 'value="Barboulevard"' in rendered

--- a/tests/test_formsetfield.py
+++ b/tests/test_formsetfield.py
@@ -1,0 +1,43 @@
+from django.forms.models import modelformset_factory
+from django.template import Context, Template
+from django.test import TestCase
+from django_superform import SuperModelForm, ModelFormSetField, InlineFormSetField
+
+from .models import Post, Image
+
+
+ImageFormSet = modelformset_factory(Image, fields=['name'])
+
+
+class PostForm(SuperModelForm):
+    class Meta:
+        model = Post
+        fields = ['title']
+
+    images_inlineformset = InlineFormSetField(Post, Image, fields=['name'])
+    images_modelformset = ModelFormSetField(ImageFormSet)
+
+    def __init__(self, *args, **kwargs):
+        super(PostForm, self).__init__(*args, **kwargs)
+        self.formsets['images_modelformset'].queryset = self.instance.images.all()
+
+
+class TestFormSetField(TestCase):
+
+    def test_inline_formset_field(self):
+        post = Post.objects.create()
+        images = [post.images.create(name='image1'), post.images.create(name='image2')]
+        form = PostForm(instance=post)
+        t = Template('{{ form.images_inlineformset }}')
+        c = Context({'form': form})
+        assert 'value="image1"' in  t.render(c)
+        assert 'value="image2"' in  t.render(c)
+
+    def test_model_formset_field(self):
+        post = Post.objects.create()
+        images = [post.images.create(name='image1'), post.images.create(name='image2')]
+        form = PostForm(instance=post)
+        t = Template('{{ form.images_modelformset }}')
+        c = Context({'form': form})
+        assert 'value="image1"' in  t.render(c)
+        assert 'value="image2"' in  t.render(c)

--- a/tests/test_modelformfield.py
+++ b/tests/test_modelformfield.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.template import Context, Template
 from django.test import TestCase
 from django_superform import SuperModelForm, ModelFormField
 
@@ -132,3 +133,12 @@ class FormFieldTests(TestCase):
         form.save()
         self.assertEqual(Post.objects.count(), 1)
         self.assertEqual(Series.objects.count(), 0)
+
+    def test_form_render(self):
+        form = PostForm(initial={
+            'series': {
+                'title': 'my title',
+            },
+        })
+        rendered = Template('{{ form.series }}').render(Context({'form': form}))
+        assert 'value="my title"' in rendered


### PR DESCRIPTION
@gregmuellegger This pull request fixes a compatibility issue in template rendering that seems to have been introduced in Django 1.9.  The fix is pretty simple (adding the `disabled` parameter). Includes tests exhibiting the issue:
```
tests/test_modelformfield.py:143: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py27-19/lib/python2.7/site-packages/django/template/base.py:206: in render
    return self._render(context)
.tox/py27-19/lib/python2.7/site-packages/django/test/utils.py:92: in instrumented_test_render
    return self.nodelist.render(context)
.tox/py27-19/lib/python2.7/site-packages/django/template/base.py:992: in render
    bit = node.render_annotated(context)
.tox/py27-19/lib/python2.7/site-packages/django/template/base.py:959: in render_annotated
    return self.render(context)
.tox/py27-19/lib/python2.7/site-packages/django/template/base.py:1049: in render
    return render_value_in_context(output, context)
.tox/py27-19/lib/python2.7/site-packages/django/template/base.py:1026: in render_value_in_context
    value = force_text(value)
.tox/py27-19/lib/python2.7/site-packages/django/utils/encoding.py:78: in force_text
    s = six.text_type(s)
.tox/py27-19/lib/python2.7/site-packages/django/utils/html.py:381: in <lambda>
    klass.__unicode__ = lambda self: mark_safe(klass_unicode(self))
.tox/py27-19/lib/python2.7/site-packages/django/forms/boundfield.py:43: in __str__
    return self.as_widget()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <django_superform.boundfield.CompositeBoundField object at 0x1115c0410>
widget = <django_superform.widgets.FormWidget object at 0x1127d9e10>, attrs = {}, only_initial = False

    def as_widget(self, widget=None, attrs=None, only_initial=False):
        """
            Renders the field by rendering the passed widget, adding any HTML
            attributes passed as attrs.  If no widget is specified, then the
            field's default widget will be used.
            """
        if not widget:
            widget = self.field.widget
    
        if self.field.localize:
            widget.is_localized = True
    
        attrs = attrs or {}
>       if self.field.disabled:
E       AttributeError: 'ModelFormField' object has no attribute 'disabled'
```