### PR TITLE
Add support for the Django 1.9 get_bound_field method.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.4.0
+-----
+* Fix formset rendering in Django 1.9. `#17`_
+* Add support for Django 1.9's ``get_bound_field``. `#18`_
+
+.. _#17: https://github.com/gregmuellegger/django-superform/pull/17
+.. _#18: https://github.com/gregmuellegger/django-superform/pull/18
+
 0.3.1
 -----
 

--- a/django_superform/fields.py
+++ b/django_superform/fields.py
@@ -1,5 +1,6 @@
 from django.forms.models import inlineformset_factory
 
+from .boundfield import CompositeBoundField
 from .widgets import FormWidget, FormSetWidget
 
 
@@ -59,6 +60,9 @@ class CompositeField(BaseCompositeField):
         # Let the widget know about the field for easier complex renderings in
         # the template.
         self.widget.field = self
+
+    def get_bound_field(self, form, field_name):
+        return CompositeBoundField(form, self, field_name)
 
     def get_prefix(self, form, name):
         """

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -82,7 +82,6 @@ from django.forms.models import ModelFormMetaclass
 from django.utils import six
 import copy
 
-from .boundfield import CompositeBoundField
 from .fields import CompositeField
 
 try:
@@ -184,7 +183,7 @@ class SuperFormMixin(object):
         """
         if name not in self.fields and name in self.composite_fields:
             field = self.composite_fields[name]
-            return CompositeBoundField(self, field, name)
+            return field.get_bound_field(self, name)
         return super(SuperFormMixin, self).__getitem__(name)
 
     def add_composite_field(self, name, field):


### PR DESCRIPTION
@gregmuellegger cc @kmmbvnr This pull request adds [the `get_bound_field` method](https://docs.djangoproject.com/en/1.10/ref/forms/api/#customizing-boundfield) which was added in Django 1.9. I suspect that this could be used to simplify some of the other implementation details of superform, but I'll save those investigations for a separate PR.