### PR TITLE
Updates for Django 3+ compatibility

### DIFF
--- a/django_superform/boundfield.py
+++ b/django_superform/boundfield.py
@@ -1,4 +1,4 @@
-from django.forms.forms import BoundField
+from django.forms import BoundField
 
 
 class CompositeBoundField(BoundField):

--- a/django_superform/forms.py
+++ b/django_superform/forms.py
@@ -79,7 +79,7 @@ from functools import reduce
 from django import forms
 from django.forms.forms import DeclarativeFieldsMetaclass, ErrorDict, ErrorList
 from django.forms.models import ModelFormMetaclass
-from django.utils import six
+import six
 import copy
 
 from .fields import CompositeField

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django>=1.8,<1.9
 Sphinx==1.3.1
+six
 -r tests/requirements.txt


### PR DESCRIPTION
Django-superform ceased functioning with Django 3.0, when they removed six from django.utils. This also fixes the broken import of the BoundField in boundfield.py as the django.forms.forms.BoundField compatibility import was removed prior to Django 3.2